### PR TITLE
fix: gate analytics behind cookie consent banner (#51)

### DIFF
--- a/src/app/Components/AnalyticsConsent.tsx
+++ b/src/app/Components/AnalyticsConsent.tsx
@@ -89,8 +89,8 @@ function AnalyticsConsent({ gaId }: AnalyticsConsentProps) {
 
   // consent === "prompt"
   return (
-    <div
-      role="dialog"
+    <dialog
+      open
       aria-live="polite"
       aria-label="Cookie consent"
       data-testid="cookie-banner"
@@ -122,7 +122,7 @@ function AnalyticsConsent({ gaId }: AnalyticsConsentProps) {
           Accept
         </button>
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/src/app/Components/AnalyticsConsent.tsx
+++ b/src/app/Components/AnalyticsConsent.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useState } from "react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
+import { Analytics } from "@vercel/analytics/next";
+import { GoogleAnalytics } from "@next/third-parties/google";
+import { IconButton, Tooltip } from "@mui/material";
+import { FiSettings } from "react-icons/fi";
+
+export type ConsentState = "loading" | "accepted" | "rejected" | "prompt";
+
+export const CONSENT_STORAGE_KEY = "analytics-consent";
+
+interface AnalyticsConsentProps {
+  readonly gaId: string;
+}
+
+function AnalyticsConsent({ gaId }: AnalyticsConsentProps) {
+  const [consent, setConsent] = useState<ConsentState>("loading");
+
+  useEffect(() => {
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem(CONSENT_STORAGE_KEY);
+    } catch {
+      // localStorage unavailable (private mode / disabled) -> prompt
+    }
+
+    if (stored === "accepted" || stored === "rejected") {
+      setConsent(stored);
+    } else {
+      setConsent("prompt");
+    }
+  }, []);
+
+  const persist = (value: Exclude<ConsentState, "loading" | "prompt">) => {
+    try {
+      localStorage.setItem(CONSENT_STORAGE_KEY, value);
+    } catch {
+      // ignore write failures; in-memory decision still applies for this session
+    }
+    setConsent(value);
+  };
+
+  const handleAccept = () => persist("accepted");
+  const handleReject = () => persist("rejected");
+  const handleReopen = () => setConsent("prompt");
+
+  if (consent === "loading") {
+    return null;
+  }
+
+  if (consent === "accepted") {
+    return (
+      <>
+        <SpeedInsights />
+        <Analytics />
+        <GoogleAnalytics gaId={gaId} />
+        <Tooltip title="Cookie settings" arrow>
+          <IconButton
+            onClick={handleReopen}
+            data-testid="cookie-settings"
+            aria-label="Reopen cookie consent settings"
+            size="small"
+            className="!fixed bottom-4 right-4 z-40 !bg-white dark:!bg-gray-900 !border !border-gray-200 dark:!border-gray-700 !text-gray-700 dark:!text-gray-300"
+          >
+            <FiSettings size={18} />
+          </IconButton>
+        </Tooltip>
+      </>
+    );
+  }
+
+  if (consent === "rejected") {
+    return (
+      <Tooltip title="Cookie settings" arrow>
+        <IconButton
+          onClick={handleReopen}
+          data-testid="cookie-settings"
+          aria-label="Reopen cookie consent settings"
+          size="small"
+          className="!fixed bottom-4 right-4 z-40 !bg-white dark:!bg-gray-900 !border !border-gray-200 dark:!border-gray-700 !text-gray-700 dark:!text-gray-300"
+        >
+          <FiSettings size={18} />
+        </IconButton>
+      </Tooltip>
+    );
+  }
+
+  // consent === "prompt"
+  return (
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label="Cookie consent"
+      data-testid="cookie-banner"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-2xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-2xl p-4 md:p-5"
+      style={{ animation: "fadeInUp 0.6s ease-out both" }}
+    >
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">
+        This site uses anonymous analytics (Google Analytics, Vercel Analytics,
+        and Vercel Speed Insights) to understand how pages are used. No personal
+        data is sold. Accept to enable analytics, or reject to keep them off.
+      </p>
+      <div className="flex gap-3 justify-end">
+        <button
+          type="button"
+          onClick={handleReject}
+          data-testid="cookie-reject"
+          aria-label="Reject analytics cookies"
+          className="px-4 py-2 rounded-lg border-2 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200 text-sm font-medium"
+        >
+          Reject
+        </button>
+        <button
+          type="button"
+          onClick={handleAccept}
+          data-testid="cookie-accept"
+          aria-label="Accept analytics cookies"
+          className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors duration-200 text-sm font-medium"
+        >
+          Accept
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default AnalyticsConsent;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import NavigationBar from "./Components/NavigationBar";
-import { SpeedInsights } from "@vercel/speed-insights/next"
-import { Analytics } from "@vercel/analytics/next";
- import { GoogleAnalytics } from '@next/third-parties/google'
+import AnalyticsConsent from "./Components/AnalyticsConsent";
 import Head from "next/head";
 
 const geistSans = Geist({
@@ -34,7 +32,7 @@ export const metadata: Metadata = {
         height: 600,
         alt: "Gagan Chatu's Profile Picture",
       },
-    ]    
+    ]
   }
 };
 
@@ -77,9 +75,7 @@ export default function RootLayout({
           <div className="backdrop-blur-sm">
             <NavigationBar/>
             {children}
-            <SpeedInsights/>
-            <Analytics/>
-            <GoogleAnalytics gaId="G-BL54PMFQ4X" />
+            <AnalyticsConsent gaId="G-BL54PMFQ4X" />
           </div>
         </div>
       </body>


### PR DESCRIPTION
## Summary

Fixes #51 — adds a lightweight, dependency-free cookie-consent banner so analytics scripts do not load until the visitor consents.

Previously `src/app/layout.tsx` loaded Google Analytics (`G-BL54PMFQ4X`) unconditionally with no consent mechanism. For visitors in GDPR / UK GDPR / ePrivacy jurisdictions, analytics that process personal data should not load until the user consents.

## Changes

- **New `src/app/Components/AnalyticsConsent.tsx`** — a `'use client'` component with a 4-state machine (`loading` → `accepted` | `rejected` | `prompt`):
  - Renders nothing on the server / first paint → no hydration mismatch, no banner flash for returning visitors.
  - Reads consent from `localStorage["analytics-consent"]` on mount (`try/catch` for private-mode / disabled-storage safety).
  - Mounts **all three** analytics components — `<SpeedInsights/>`, `<Analytics/>`, `<GoogleAnalytics gaId={gaId}/>` — **only** when consent is `accepted`, so none load before consent.
  - Shows a fixed bottom-center banner with an inline summary and equally prominent **Reject** / **Accept** buttons (GDPR parity: Reject is first and the same size as Accept). Both persist the choice and hide the banner immediately.
  - A small bottom-right "Cookie settings" `IconButton` re-opens the banner after a decision.
  - Entrance animation reuses the existing `fadeInUp` keyframe from `globals.css`.
- **`src/app/layout.tsx`** — removed the three analytics imports/tags and replaced them with a single `<AnalyticsConsent gaId="G-BL54PMFQ4X" />`. The GA id stays a hardcoded literal prop (no env-var infrastructure introduced).

## Verification

- `npx tsc --noEmit` → passes
- `npm run lint` → passes
- `npm run build` → succeeds (all routes compile)
- Runtime: started dev server, fetched `/` — initial HTML contains **no** analytics markers (`googletagmanager`, `gtag`, `vercel-analytics`, `speed-insights`) and no banner (client-only), confirming the gating works at SSR
- Manual flow: fresh visit shows banner + no analytics requests; Accept loads scripts; Reject loads none; reload after a decision respects stored choice; Cookie-settings re-opens the banner

## Notes / out of scope

- No new dependency added (uses existing `@mui/material`, `react-icons`, `@next/third-parties`, `@vercel/*`).
- No separate privacy page — the banner uses inline text only (per the issue discussion).
- Runtime unloading of already-injected scripts isn't supported by these libraries; re-rejection via Cookie-settings takes effect on next reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)