### PR TITLE
chore: ignore TypeScript incremental build info (*.tsbuildinfo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ build
 .next
 next-env.d.ts
 
+# TypeScript incremental build info
+*.tsbuildinfo
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
Adds `*.tsbuildinfo` to `.gitignore` so TypeScript's incremental build artifact (`tsconfig.tsbuildinfo`) stops appearing as an untracked file. No code changes.